### PR TITLE
Added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Mac stores .DS_Store files invisibly in every folder. This will prevent Mac users from uploading files that shouldn't be on our repository. (Plus, this is good practice with branches and whatnot)